### PR TITLE
Fix Map comparison under pypy.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,22 @@
+# Enables support for a docker container-based build,
+# see: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+sudo: false
+
 language: python
-python: 2.7
+
+# We default python to 3.5 to make sure its installed and available for the
+# TOXENV=py35 case.  Without this (say defaulting to 2.7), that lone case fails
+# from not finding a python3.5.
+python: 3.5
+
 env:
   - TOXENV=py26
   - TOXENV=py27
+  - TOXENV=py33
   - TOXENV=py34
+  - TOXENV=py35
   - TOXENV=pypy
+  - TOXENV=pypy3
 install:
   - pip install tox
 script:

--- a/pystachio/container.py
+++ b/pystachio/container.py
@@ -245,7 +245,7 @@ class MapContainer(Object, Namable, Type):
     if self.VALUETYPE.serialize_type() != other.VALUETYPE.serialize_type(): return False
     si, _ = self.interpolate()
     oi, _ = other.interpolate()
-    return si._map == oi._map
+    return si.get() == oi.get()
 
   def check(self):
     assert isinstance(self._map, tuple)

--- a/pystachio/naming.py
+++ b/pystachio/naming.py
@@ -14,6 +14,18 @@ class frozendict(dict):
   def __eq__(self, other):
     return self.__key() == other.__key()
 
+  def __lt__(self, other):
+    return self.__key() < other.__key()
+
+  def __le__(self, other):
+    return self.__key() <= other.__key()
+
+  def __gt__(self, other):
+    return self.__key() > other.__key()
+
+  def __ge__(self, other):
+    return self.__key() >= other.__key()
+
   def __repr__(self):
     return 'frozendict(%s)' % dict.__repr__(self)
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,9 @@ envlist =
         py27,
         py33,
         py34,
-        pypy
+        py35,
+        pypy,
+        pypy3
 
 [testenv]
 commands = py.test --basetemp={envtmpdir} -n 4 {posargs:}
@@ -51,8 +53,14 @@ basepython = python3.3
 [testenv:py34]
 basepython = python3.4
 
+[testenv:py35]
+basepython = python3.5
+
 [testenv:pypy]
 basepython = pypy
+
+[testenv:pypy3]
+basepython = pypy3
 
 [testenv:jython]
 basepython = jython


### PR DESCRIPTION
Previously Map indirectly relied on dict iteration order in its __eq__
implementation and this blew up under pypy.  Now Map uses the same
stable comparison structure returned by get() as it uses in its __hash__
which has the side-benefit of being easier to reason about; ie: the hash
and == relationship is now more obviously sane.
