### PR TITLE
Improve travis-ci setup and coverage.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,23 @@
+# Enables support for a docker container-based build,
+# see: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+sudo: false
+
 language: python
-python: 2.7
+
+# We default python to 3.5 to make sure its installed and available for the
+# TOXENV=py35 case.  Without this (say defaulting to 2.7), that lone case fails
+# from not finding a python3.5.
+python: 3.5
+
 env:
   - TOXENV=isort-check
   - TOXENV=py26
   - TOXENV=py27
+  - TOXENV=py33
   - TOXENV=py34
+  - TOXENV=py35
   - TOXENV=pypy
+  - TOXENV=pypy3
 install:
   - pip install tox
 script:

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,9 @@ envlist =
         py27,
         py33,
         py34,
-        pypy
+        py35,
+        pypy,
+        pypy3
 
 [testenv]
 commands = py.test --basetemp={envtmpdir} -n 4 {posargs:}
@@ -61,8 +63,14 @@ basepython = python3.3
 [testenv:py34]
 basepython = python3.4
 
+[testenv:py35]
+basepython = python3.5
+
 [testenv:pypy]
 basepython = pypy
+
+[testenv:pypy3]
+basepython = pypy3
 
 [testenv:jython]
 basepython = jython


### PR DESCRIPTION
This adds py3.5 and pypy3 test environments.

Takes over for #14.