### PR TITLE
Cleanup imports and add CI checks.

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,5 @@
+[settings]
+line_length=100
+known_first_party=pystachio
+multi_line_output=3
+default_section=THIRDPARTY

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python: 2.7
 env:
+  - TOXENV=isort-check
   - TOXENV=py26
   - TOXENV=py27
   - TOXENV=py34

--- a/pystachio/basic.py
+++ b/pystachio/basic.py
@@ -1,11 +1,7 @@
 from .base import Object
 from .compatibility import Compatibility
 from .parsing import MustacheParser
-from .typing import (
-    Type,
-    TypeCheck,
-    TypeFactory,
-    TypeMetaclass)
+from .typing import Type, TypeCheck, TypeFactory, TypeMetaclass
 
 
 class SimpleObject(Object, Type):

--- a/pystachio/compatibility.py
+++ b/pystachio/compatibility.py
@@ -1,5 +1,5 @@
+from numbers import Integral, Real
 from sys import version_info
-from numbers import (Real, Integral)
 
 
 class Compatibility(object):

--- a/pystachio/composite.py
+++ b/pystachio/composite.py
@@ -1,15 +1,11 @@
-from collections import Mapping
 import copy
-from inspect import isclass
 import json
+from collections import Mapping
+from inspect import isclass
 
-from .base import Object, Environment
-from .naming import Namable, Ref, frozendict
-from .typing import (
-  Type,
-  TypeCheck,
-  TypeFactory,
-  TypeMetaclass)
+from .base import Environment, Object
+from .naming import Namable, frozendict
+from .typing import Type, TypeCheck, TypeFactory, TypeMetaclass
 
 
 class Empty(object):

--- a/pystachio/container.py
+++ b/pystachio/container.py
@@ -1,15 +1,11 @@
-from collections import Iterable, Mapping, Sequence
 import copy
+from collections import Iterable, Mapping, Sequence
 from inspect import isclass
 
 from .base import Object
 from .compatibility import Compatibility
 from .naming import Namable, frozendict
-from .typing import (
-    Type,
-    TypeCheck,
-    TypeFactory,
-    TypeMetaclass)
+from .typing import Type, TypeCheck, TypeFactory, TypeMetaclass
 
 
 class ListFactory(TypeFactory):

--- a/pystachio/matcher.py
+++ b/pystachio/matcher.py
@@ -1,12 +1,14 @@
 import copy
-try:
-  from itertools import izip_longest as zipl
-except ImportError:
-  from itertools import zip_longest as zipl
 import re
 
 from .compatibility import Compatibility
 from .naming import Ref
+
+try:
+  from itertools import izip_longest as zipl
+except ImportError:
+  from itertools import zip_longest as zipl
+
 
 
 class Any(object):

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from setuptools import setup, find_packages, Command
+from setuptools import Command, find_packages, setup
 
 version = '0.8.0'
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,9 +1,10 @@
 import pytest
-from pystachio.base import Object, Environment
-from pystachio.naming import Ref, Namable
-from pystachio.basic import Integer, String
-from pystachio.container import List, Map
-from pystachio.composite import Struct
+
+from pystachio.base import Environment, Object
+from pystachio.basic import Integer
+from pystachio.container import List
+from pystachio.naming import Namable, Ref
+
 
 def dtd(d):
   return dict((Ref.from_address(key), str(val)) for key, val in d.items())

--- a/tests/test_basic_types.py
+++ b/tests/test_basic_types.py
@@ -1,11 +1,6 @@
 import pytest
-from pystachio.basic import (
-    Boolean,
-    Enum,
-    Float,
-    Integer,
-    SimpleObject,
-    String)
+
+from pystachio.basic import Boolean, Enum, Float, Integer, SimpleObject, String
 
 
 def unicodey(s):

--- a/tests/test_bigger_examples.py
+++ b/tests/test_bigger_examples.py
@@ -1,5 +1,6 @@
 from pystachio import *
 
+
 class CommandLine(Struct):
   binary = Required(String)
   args   = List(String)

--- a/tests/test_composite_types.py
+++ b/tests/test_composite_types.py
@@ -1,8 +1,10 @@
 import pytest
+
 from pystachio.basic import *
 from pystachio.composite import *
-from pystachio.container import Map, List
+from pystachio.container import List, Map
 from pystachio.naming import Ref
+
 
 def ref(address):
   return Ref.from_address(address)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,14 +1,14 @@
 import contextlib
-from io import BytesIO
 import json
 import os
 import shutil
 import tempfile
 import textwrap
-
-from pystachio.config import Config, ConfigContext
+from io import BytesIO
 
 import pytest
+
+from pystachio.config import Config, ConfigContext
 
 
 @contextlib.contextmanager
@@ -106,4 +106,3 @@ def test_filelike_config():
   foo = b"include('derp')\na = 'Hello'"
   with pytest.raises(Config.InvalidConfigError):
     config = Config(BytesIO(foo))
-

--- a/tests/test_container_types.py
+++ b/tests/test_container_types.py
@@ -1,11 +1,13 @@
-import json
 import os
-import pytest
 import tempfile
-from pystachio.naming import Ref, Namable
+
+import pytest
+
 from pystachio.basic import *
+from pystachio.composite import Default, Struct
 from pystachio.container import List, Map
-from pystachio.composite import Struct, Default
+from pystachio.naming import Namable, Ref
+
 
 def ref(address):
   return Ref.from_address(address)

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -1,7 +1,5 @@
-import copy
-
 from pystachio import *
-from pystachio.matcher import Matcher, Any
+from pystachio.matcher import Any, Matcher
 
 
 def test_matcher():

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -1,12 +1,11 @@
 from copy import deepcopy
+
 import pytest
 
-from pystachio.base import Environment
-from pystachio.naming import Ref, Namable, frozendict
-
 from pystachio.basic import *
-from pystachio.container import *
 from pystachio.composite import *
+from pystachio.container import *
+from pystachio.naming import Ref
 
 
 def ref(address):
@@ -133,4 +132,3 @@ def test_deepcopy_preserves_bindings():
   briancopy = deepcopy(brian)
   assert brian.find(ref('number')) == Integer(4025551234)
   assert briancopy.find(ref('number')) == Integer(4025551234)
-

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -2,7 +2,7 @@ import pytest
 
 from pystachio.base import Environment
 from pystachio.basic import String
-from pystachio.composite import Struct, Required, Default
+from pystachio.composite import Default, Required, Struct
 from pystachio.container import List
 from pystachio.naming import Ref
 from pystachio.parsing import MustacheParser
@@ -103,4 +103,3 @@ def test_mustache_resolve_cycles():
   with pytest.raises(MustacheParser.Uninterpolatable):
     MustacheParser.resolve('{{foo[{{bar}}]}} {{baz}}',
        Environment(foo = List(String)(["{{foo[{{bar}}]}}", "world"])), Environment(bar = 0))
-

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,5 +1,7 @@
 import pytest
+
 from pystachio import *
+
 
 def ref(address):
   return Ref.from_address(address)

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,16 @@ changedir = tests
 # Remove it (it's not a part of {opts}) to only install real releases.
 install_command = pip install {opts} {packages}
 
+[testenv:isort-run]
+basepython = python2.7
+deps = isort
+commands = isort -ns __init__.py -rc {toxinidir}/setup.py {toxinidir}/pystachio {toxinidir}/tests
+
+[testenv:isort-check]
+basepython = python2.7
+deps = isort
+commands = isort -ns __init__.py -rc -c {toxinidir}/setup.py {toxinidir}/pystachio {toxinidir}/tests
+
 [testenv:py26]
 basepython = python2.6
 


### PR DESCRIPTION
This kills unused imports globally and sets up isort for local checks
and fixes as well as setting up a CI gating check to make sure imports
stay uniform.