### PR TITLE
Unwrap Choice types when stringifying so they can be used in staches

### DIFF
--- a/pystachio/choice.py
+++ b/pystachio/choice.py
@@ -59,8 +59,13 @@ class ChoiceContainer(Object, Type):
   def __hash(self):
     return hash(self.get())
 
+  def __unicode__(self):
+    return unicode(self.unwrap())
+
+  def __str__(self):
+    return str(self.unwrap())
+
   def __repr__(self):
-    si, _ = self.interpolate()
     return '%s(%s)' % (self.__class__.__name__,
                        repr(self._value))
 

--- a/tests/test_choice.py
+++ b/tests/test_choice.py
@@ -181,6 +181,27 @@ def test_repr():
   assert repr(testvaltwo) == "Choice_String_IntegerList([1, 2, 3])"
 
 
+def test_choice_in_stache():
+  class Foo(Struct):
+    x = Integer
+
+  class Bar(Struct):
+    a = Choice("StringOrFoo", [Integer, String, Foo])
+    b = String
+
+  stringbar = Bar(a="hello", b="{{a}} world!")
+  assert stringbar.check().ok()
+  assert json.loads(stringbar.json_dumps()) == {'a': 'hello', 'b': 'hello world!'}
+
+  intbar = Bar(a=4, b="{{a}} world!")
+  assert intbar.check().ok()
+  assert json.loads(intbar.json_dumps()) == {'a': 4, 'b': '4 world!'}
+
+  foobar = Bar(a=Foo(x=5), b='{{a}} world!')
+  assert foobar.check().ok()
+  assert json.loads(foobar.json_dumps()) == {'a': {'x': 5}, 'b': 'Foo(x=5) world!'}
+
+
 def test_get_choice_in_struct():
   class Foo(Struct):
     foo = Required(String)


### PR DESCRIPTION
This change defines `__str__` and `__unicode__` on the Choice type such that it returns the stringified result of the underlying value.

Previously, it was difficult to use a Choice type in a stache expression, since the result would always be stringified as a Choice struct, even if the underlying value were a basic type.

For example, given the following Choice type:
`C = Choice([Integer, String])`

One might want to use the value in a stache template, since both Integer and String are basic types. Previously, this would result in a stache substitution like `Choice_Integer_String('hello')`. With this change, it will result in a stache substitution of just the underlying value `hello`.