### PR TITLE
duck-type choice of structs

### DIFF
--- a/pystachio/choice.py
+++ b/pystachio/choice.py
@@ -102,7 +102,7 @@ class ChoiceContainer(Object, Type):
           ret = ret_fun(o)
           if ret:
             return ret
-        except (self.CoercionError, ValueError):
+        except (self.CoercionError, ValueError, AttributeError):
           pass
     return err_fun(self._value)
 

--- a/tests/test_choice.py
+++ b/tests/test_choice.py
@@ -216,3 +216,39 @@ def test_get_choice_in_struct():
 
   b = Qux(item=[Foo(foo="fubar")])
   assert b.get() == frozendict({'item': (frozendict({'foo': u'fubar'}),)})
+
+
+def test_choice_of_structs():
+  class Foo(Struct):
+    foo = Required(String)
+
+  class Bar(Struct):
+    bar = Required(String)
+
+  class Stuff(Struct):
+    item = Required(Choice((Foo, Bar)))
+
+  thing_one = Stuff(item={ 'foo': 'a' })
+  assert thing_one.get() == frozendict({ 'item': frozendict({ 'foo': u'a' }) })
+
+  thing_two = Stuff(item={ 'bar': 'b' })
+  assert thing_two.get() == frozendict({ 'item': frozendict({ 'bar': u'b' }) })
+
+
+def test_list_choice_of_structs():
+  class Foo(Struct):
+    foo = Required(String)
+
+  class Bar(Struct):
+    bar = Required(String)
+
+  class Stuff(Struct):
+    items = Required(List(Choice((Foo, Bar))))
+
+  stuff = Stuff(items=[{ 'foo': 'a' }, { 'bar': 'b' }])
+  assert stuff.get() == frozendict({
+    'items': (
+      frozendict({ 'foo': u'a' }),
+      frozendict({ 'bar': u'b' })
+    )
+  })


### PR DESCRIPTION
`Choice` of multiple `Struct`s fails when given a valid schema for any but the first option, since the first `Struct` will raise an unhandled `AttributeError` before the others are tried.

Might make sense instead to change `AttributeError` to `ValueError` in `_process_schema_attribute` composite.py.