### PR TITLE
Fix equality and hashing in Python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ build/*
 dist/*
 .tox
 .coverage
+.pytest_cache/
 tests/htmlcov
 TODO

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,21 +4,17 @@ sudo: false
 
 language: python
 
-# We default python to 3.5 to make sure its installed and available for the
-# TOXENV=py35 case.  Without this (say defaulting to 2.7), that lone case fails
-# from not finding a python3.5.
-python: 3.5
+python:
+  - "2.6"
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "pypy"
+  - "pypy3"
 
-env:
-  - TOXENV=isort-check
-  - TOXENV=py26
-  - TOXENV=py27
-  - TOXENV=py33
-  - TOXENV=py34
-  - TOXENV=py35
-  - TOXENV=pypy
-  - TOXENV=pypy3
 install:
-  - pip install tox
+  - pip install tox-travis
 script:
-  - tox -v
+  - tox
+  - tox -e isort-check

--- a/pystachio/choice.py
+++ b/pystachio/choice.py
@@ -56,7 +56,7 @@ class ChoiceContainer(Object, Type):
   def dup(self):
     return self.__class__(self._value)
 
-  def __hash(self):
+  def __hash__(self):
     return hash(self.get())
 
   def __unicode__(self):

--- a/pystachio/choice.py
+++ b/pystachio/choice.py
@@ -75,11 +75,11 @@ class ChoiceContainer(Object, Type):
     if len(self.CHOICES) != len(other.CHOICES):
       return False
     for myalt, otheralt in zip(self.CHOICES, other.CHOICES):
-      if myalt.serialize_type() != other.serialize_type():
+      if myalt.serialize_type() != otheralt.serialize_type():
         return False
     si, _ = self.interpolate()
     oi, _ = other.interpolate()
-    return si._value == other._value
+    return si._value == oi._value
 
   def _unwrap(self, ret_fun, err_fun):
     """Iterate over the options in the choice type, and try to perform some

--- a/pystachio/composite.py
+++ b/pystachio/composite.py
@@ -50,6 +50,13 @@ class TypeSignature(object):
     else:
       return TypeSignature(real_class, required=req)
 
+  def __hash__(self):
+    return hash(
+      self.klazz.serialize_type(),
+      self.required,
+      self.default,
+      self.empty)
+
   def __eq__(self, other):
     return (self.klazz.serialize_type() == other.klazz.serialize_type() and
             self.required == other.required and
@@ -190,6 +197,9 @@ class Structural(Object, Type, Namable):
     new_self = self.copy()
     new_self._update_schema_data(**copy.copy(kw))
     return new_self
+
+  def __hash__(self):
+    return hash(self.get())
 
   def __eq__(self, other):
     if not isinstance(other, Structural): return False

--- a/pystachio/naming.py
+++ b/pystachio/naming.py
@@ -14,6 +14,9 @@ class frozendict(dict):
   def __eq__(self, other):
     return self.__key() == other.__key()
 
+  def __ne__(self, other):
+    return self.__key() != other.__key()
+
   def __repr__(self):
     return 'frozendict(%s)' % dict.__repr__(self)
 
@@ -68,6 +71,9 @@ class Ref(object):
     @property
     def value(self):
       return self._value
+
+    def __hash__(self):
+      return hash(self.value)
 
     def __eq__(self, other):
       return self.__class__ == other.__class__ and self.value == other.value
@@ -185,6 +191,9 @@ class Ref(object):
 
   def __eq__(self, other):
     return self.components() == other.components()
+
+  def __ne__(self, other):
+    return self.components() != other.components()
 
   @staticmethod
   def compare(self, other):

--- a/tests/test_basic_types.py
+++ b/tests/test_basic_types.py
@@ -113,12 +113,18 @@ def test_cmp():
   assert Integer(1) < Integer(2)
   assert Integer(2) > Integer(1)
   assert Integer(1) == Integer(1)
+  assert not Integer(1) == Integer(2)
+  assert Integer(1) != Integer(2)
+  assert not Integer(1) != Integer(1)
   assert String("a") < String("b")
   assert String("a") == String("a")
   assert String("b") > String("a")
   assert Float(1) < Float(2)
   assert Float(2) > Float(1)
   assert Float(1) == Float(1)
+  assert not Float(1) == Float(1.1)
+  assert Float(1) != Float(1.1)
+  assert not Float(1) != Float(1)
   assert Float(1.1) > Float(1)
 
   # all types <

--- a/tests/test_choice.py
+++ b/tests/test_choice.py
@@ -221,3 +221,19 @@ def test_get_choice_in_struct():
 
   b = Qux(item=[Foo(foo="fubar")])
   assert b.get() == frozendict({'item': (frozendict({'foo': u'fubar'}),)})
+
+
+def test_hashing():
+  IntStr = Choice("IntStrFloat", (Integer, String))
+
+  map = {
+    IntStr(123): 'foo',
+    IntStr("123"): 'bar',
+    IntStr("abc"): 'baz'
+  }
+  assert IntStr(123) in map
+  assert IntStr("123") in map
+  assert IntStr("abc") in map
+  assert IntStr(456) not in map
+  assert IntStr("456") not in map
+  assert IntStr("def") not in map

--- a/tests/test_choice.py
+++ b/tests/test_choice.py
@@ -9,6 +9,11 @@ def test_choice_type():
   one = IntStr(123)
   two = IntStr("123")
   three = IntStr("abc")
+
+  assert one == IntStr(123)
+  assert two == IntStr("123")
+  assert three == IntStr("abc")
+
   assert one.unwrap() == Integer(123)
   assert two.unwrap() == Integer(123)
   assert three.unwrap() == String("abc")

--- a/tests/test_choice.py
+++ b/tests/test_choice.py
@@ -14,6 +14,11 @@ def test_choice_type():
   assert two == IntStr("123")
   assert three == IntStr("abc")
 
+  assert one == two
+  assert not one == three
+  assert one != three
+  assert not one != two
+
   assert one.unwrap() == Integer(123)
   assert two.unwrap() == Integer(123)
   assert three.unwrap() == String("abc")

--- a/tests/test_composite_types.py
+++ b/tests/test_composite_types.py
@@ -234,3 +234,25 @@ def test_self_super():
   parent = Parent(child=Child(value=23), value='{{self.child.value}}')
   parent, _ = parent.interpolate()
   assert parent.child().value().get() == 23
+
+
+def test_hashing():
+  class Resources(Struct):
+    cpu = Float
+    ram = Integer
+  class Process(Struct):
+    name = String
+    resources = Resources
+
+  map = {
+    Resources(): 'foo',
+    Process(): 'bar',
+    Resources(cpu=1.1): 'baz',
+    Process(resources=Resources(cpu=1.1)): 'derp'
+  }
+  assert Resources() in map
+  assert Process() in map
+  assert Resources(cpu=1.1) in map
+  assert Resources(cpu=2.2) not in map
+  assert Process(resources=Resources(cpu=1.1)) in map
+  assert Process(resources=Resources(cpu=2.2)) not in map

--- a/tests/test_composite_types.py
+++ b/tests/test_composite_types.py
@@ -71,6 +71,9 @@ def test_defaults():
     cpu = Default(Float, 1.0)
     ram = Integer
   assert Resources() == Resources(cpu = 1.0)
+  assert not Resources() == Resources(cpu = 2.0)
+  assert Resources() != Resources(cpu = 2.0)
+  assert not Resources() != Resources(cpu = 1.0)
   assert Resources(cpu = 2.0)._schema_data['cpu'] == Float(2.0)
 
   class Process(Struct):

--- a/tests/test_container_types.py
+++ b/tests/test_container_types.py
@@ -90,6 +90,9 @@ def test_list_find():
 
 def test_equals():
   assert List(Integer)([1, "{{wut}}"]).bind(wut=23) == List(Integer)([1, 23])
+  assert not List(Integer)([1, 2]) == List(Integer)([1, 3])
+  assert List(Integer)([1, 2]) != List(Integer)([1, 3])
+  assert not List(Integer)([1, "{{wut}}"]).bind(wut=23) != List(Integer)([1, 23])
 
 def test_basic_maps():
   assert Map(String,Integer)({}).check().ok()

--- a/tox.ini
+++ b/tox.ini
@@ -9,11 +9,12 @@ envlist =
         # and with all optional dependencies.
         py26,
         py27,
-        py33,
         py34,
         py35,
+        py36,
         pypy,
-        pypy3
+        pypy3,
+        isort-check
 
 [testenv]
 commands = py.test --basetemp={envtmpdir} -n 4 {posargs:}
@@ -57,14 +58,14 @@ commands = py.test \
     --cov=pystachio --cov-report=term-missing --cov-report=html \
     {posargs:}
 
-[testenv:py33]
-basepython = python3.3
-
 [testenv:py34]
 basepython = python3.4
 
 [testenv:py35]
 basepython = python3.5
+
+[testenv:py36]
+basepython = python3.6
 
 [testenv:pypy]
 basepython = pypy


### PR DESCRIPTION
The combination of `__ne__`, `__eq__`, and `__hash__` is surprisingly tricky especially if multiple Python versions are in play:

*  When defining `__eq__` in Python 2, one should also define `__ne__` so that the operators will behave as expected. This is no longer necessary in Python 3 as there is a default `__ne__` implementation that delegates to `__eq__` and inverts the result. 
* It is okay to implement `__ne__` in a base class and make it available to subclasses. This is done in pystachio for any class deriving from `base.Object`. Classes with a custom `__eq__` which are not deriving from `base.Object` still need a custom `__ne__` implementation to make Python 2 work as expected.
* Classes which inherit a `__hash__` method from a parent class but change the meaning of  `__eq__` behave differently in Python 2 and Python 3. In Python 2 one can silently break the contract that equal objects should also have the same hashcode. Python 3 prevents this issue. A class that overrides `__eq__` and does not define `__hash__` will have its `__hash__` implicitly set to None. 

In summary:
* We always have to reimplement `__hash__` when we reimplement `__eq__` for a class. We cannot rely on inheritance here.
* When implementing `__eq__` we also need to have an implementation of `__ne__`. It is okay to inherit this implementation from a parent class.

For further information see https://docs.python.org/3/reference/datamodel.html#object.__hash__ and  https://docs.python.org/2/reference/datamodel.html#object.__hash__ 