### PR TITLE
Improve performance of composites and containers 

### DIFF
--- a/pystachio/composite.py
+++ b/pystachio/composite.py
@@ -230,11 +230,12 @@ class Structural(Object, Type, Namable):
     return lambda: self.interpolate_key(attr)
 
   def check(self):
+    scopes = self.scopes()
     for name, signature in self.TYPEMAP.items():
       if self._schema_data[name] is Empty and signature.required:
         return TypeCheck.failure('%s[%s] is required.' % (self.__class__.__name__, name))
       elif self._schema_data[name] is not Empty:
-        type_check = self._schema_data[name].in_scope(*self.scopes()).check()
+        type_check = self._schema_data[name].in_scope(*scopes).check()
         if type_check.ok():
           continue
         else:

--- a/pystachio/container.py
+++ b/pystachio/container.py
@@ -85,9 +85,10 @@ class ListContainer(Object, Namable, Type):
 
   def check(self):
     assert ListContainer.isiterable(self._values)
+    scopes = self.scopes()
     for element in self._values:
       assert isinstance(element, self.TYPE)
-      typecheck = element.in_scope(*self.scopes()).check()
+      typecheck = element.in_scope(*scopes).check()
       if not typecheck.ok():
         return TypeCheck.failure("Element in %s failed check: %s" % (self.__class__.__name__,
           typecheck.message()))
@@ -96,8 +97,9 @@ class ListContainer(Object, Namable, Type):
   def interpolate(self):
     unbound = set()
     interpolated = []
+    scopes = self.scopes()
     for element in self._values:
-      einterp, eunbound = element.in_scope(*self.scopes()).interpolate()
+      einterp, eunbound = element.in_scope(*scopes).interpolate()
       interpolated.append(einterp)
       unbound.update(eunbound)
     return self.__class__(interpolated), list(unbound)
@@ -245,11 +247,12 @@ class MapContainer(Object, Namable, Type):
 
   def check(self):
     assert isinstance(self._map, tuple)
+    scopes = self.scopes()
     for key, value in self._map:
       assert isinstance(key, self.KEYTYPE)
       assert isinstance(value, self.VALUETYPE)
-      keycheck = key.in_scope(*self.scopes()).check()
-      valuecheck = value.in_scope(*self.scopes()).check()
+      keycheck = key.in_scope(*scopes).check()
+      valuecheck = value.in_scope(*scopes).check()
       if not keycheck.ok():
         return TypeCheck.failure("%s key %s failed check: %s" % (self.__class__.__name__,
           key, keycheck.message()))
@@ -261,9 +264,10 @@ class MapContainer(Object, Namable, Type):
   def interpolate(self):
     unbound = set()
     interpolated = []
+    scopes = self.scopes()
     for key, value in self._map:
-      kinterp, kunbound = key.in_scope(*self.scopes()).interpolate()
-      vinterp, vunbound = value.in_scope(*self.scopes()).interpolate()
+      kinterp, kunbound = key.in_scope(*scopes).interpolate()
+      vinterp, vunbound = value.in_scope(*scopes).interpolate()
       unbound.update(kunbound)
       unbound.update(vunbound)
       interpolated.append((kinterp, vinterp))
@@ -273,15 +277,16 @@ class MapContainer(Object, Namable, Type):
     if not ref.is_index():
       raise Namable.NamingError(self, ref)
     kvalue = self.KEYTYPE(ref.action().value)
+    scopes = self.scopes()
     for key, namable in self._map:
       if kvalue == key:
         if ref.rest().is_empty():
-          return namable.in_scope(*self.scopes())
+          return namable.in_scope(*scopes)
         else:
           if not isinstance(namable, Namable):
             raise Namable.Unnamable(namable)
           else:
-            return namable.in_scope(*self.scopes()).find(ref.rest())
+            return namable.in_scope(*scopes).find(ref.rest())
     raise Namable.NotFound(self, ref)
 
   @classmethod

--- a/pystachio/naming.py
+++ b/pystachio/naming.py
@@ -124,7 +124,7 @@ class Ref(object):
     return Ref(components)
 
   def __init__(self, components):
-    self._components = components
+    self._components = tuple(components)
 
   def components(self):
     return self._components
@@ -211,4 +211,4 @@ class Ref(object):
     return Ref.compare(self, other) == 1
 
   def __hash__(self):
-    return hash(str(self))
+    return hash(self.components())


### PR DESCRIPTION
This partially addresses #24 with two changes:

* For nested elements compute (immutable) scope only once
* Ensure hashing of Ref does not allocate short lived strings. This prevents a large number of unnecessary memory allocations.

The changes can be verified with the following simple benchmark: 
```
--- a/tests/test_bigger_examples.py
+++ b/tests/test_bigger_examples.py
@@ -31,10 +31,8 @@ def test_simple_task():
     cmdline = command)
   basic = Task(name = "basic")(
     processes = [
-      process_template.bind(process = {'name': 'process_1'}),
-      process_template.bind(process = {'name': 'process_2'}),
-      process_template.bind(process = {'name': 'process_3'}),
-    ])
+      process_template.bind(process = {'name': str(i)})  for i in range(500)
+  ])

   bi, unbound = basic.interpolate()
   assert unbound == [Ref.from_address('mesos.datacenter')]
```

Performance before:
```
$ py.test tests/test_bigger_examples.py::test_simple_task -vv --durations=0

2.78s call     tests/test_bigger_examples.py::test_simple_task
```

Performance after:
```
$ py.test tests/test_bigger_examples.py::test_simple_task -vv --durations=0

1.88s call     tests/test_bigger_examples.py::test_simple_task
```
