### PR TITLE
Improve performance of passing a non-Mapping object to a Structural

### DIFF
--- a/pystachio/composite.py
+++ b/pystachio/composite.py
@@ -157,6 +157,14 @@ class StructMetaclass(type):
     else:
       return type.__new__(mcs, name, parents, attributes)
 
+class IsNotMappingError(ValueError):
+  """Raised when a composite argument is not a Mapping"""
+
+  def __init__(self, arg):
+    self.arg = arg
+
+  def __repr__(self):
+    return 'IsNotMappingError({!r})'.format(self.arg)
 
 StructMetaclassWrapper = StructMetaclass('StructMetaclassWrapper', (object,), {})
 class Structural(Object, Type, Namable):
@@ -167,7 +175,7 @@ class Structural(Object, Type, Namable):
     self._schema_data = frozendict((attr, value.default) for (attr, value) in self.TYPEMAP.items())
     for arg in args:
       if not isinstance(arg, Mapping):
-        raise ValueError('Expected dictionary argument, got %s' % repr(arg))
+        raise IsNotMappingError(arg)
       self._update_schema_data(**arg)
     self._update_schema_data(**copy.copy(kw))
     super(Structural, self).__init__()


### PR DESCRIPTION
Problem
-------

Serializing large configurations use a lot of CPU time. Profiling
revealed that about 50% of the CPU time was due to calling __repr__,
which seemed suspicious. This is because we are using repr() to
instantiate a ValueError that is immediately caught and discarded.

Solution
--------

Create a subclass of ValueError that lazily renders the message,
avoiding the call to repr in the hot path (ChoiceContainer._unwrap).

For the files that I was testing with, this made them run about
twice as fast.