### PR TITLE
Drop support for EOL versions, fix 3.8 __classcell__ RuntimeError

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,7 @@ Notable related projects:
 
 ## Requirements ##
 
-Tested and works in CPython 2.6.7, 2.7.2, 3.2.1 and PyPy 1.6.  Not tested
-pre-2.6.x and will almost certainly not work.  Due to http://bugs.python.org/issue2646,
-serialization to/from json will likely break CPython 2.6.1 and earlier because unicode
-kwargs keys are not supported.
+Tested and works in CPython 3.6, 3.7, 3.8, and PyPy 1.6.
 
 ## Overview ##
 

--- a/pystachio/composite.py
+++ b/pystachio/composite.py
@@ -153,6 +153,9 @@ class StructMetaclass(type):
   def __new__(mcs, name, parents, attributes):
     if any(parent.__name__ == 'Struct' for parent in parents):
       type_parameters = StructMetaclass.attributes_to_parameters(attributes)
+      class_cell = attributes.pop('__classcell__', None)
+      if class_cell is not None:
+        type_parameters['__classcell__'] = class_cell
       return TypeFactory.new({}, 'Struct', name, type_parameters)
     else:
       return type.__new__(mcs, name, parents, attributes)

--- a/tox.ini
+++ b/tox.ini
@@ -7,11 +7,9 @@
 envlist =
         # Basic configurations: Run the tests in both minimal installations
         # and with all optional dependencies.
-        py26,
-        py27,
-        py34,
-        py35,
         py36,
+        py37,
+        py38,
         pypy,
         pypy3,
         isort-check
@@ -35,37 +33,31 @@ changedir = tests
 install_command = pip install {opts} {packages}
 
 [testenv:isort-run]
-basepython = python2.7
+basepython = python3.8
 deps = isort
 commands = isort -ns __init__.py -rc {toxinidir}/setup.py {toxinidir}/pystachio {toxinidir}/tests
 
 [testenv:isort-check]
-basepython = python3.4
+basepython = python3.8
 deps = isort
 commands = isort -ns __init__.py -rc -c {toxinidir}/setup.py {toxinidir}/pystachio {toxinidir}/tests
 
-[testenv:py26]
-basepython = python2.6
-
-[testenv:py27]
-basepython = python2.7
-
 [testenv:coverage]
-basepython = python2.7
+basepython = python3.8
 commands = py.test \
     --basetemp={envtmpdir} \
     -n 4 \
     --cov=pystachio --cov-report=term-missing --cov-report=html \
     {posargs:}
 
-[testenv:py34]
-basepython = python3.4
-
-[testenv:py35]
-basepython = python3.5
-
 [testenv:py36]
 basepython = python3.6
+
+[testenv:py37]
+basepython = python3.7
+
+[testenv:py38]
+basepython = python3.7
 
 [testenv:pypy]
 basepython = pypy


### PR DESCRIPTION
Users cannot define subclasses of Struct in python3.8+ because the __classcell__ is not propagated to type.__new__
```
monitoring-configs/jcrawford/test/test_child_sources_pex__pex_root/mon/monitor.py:270: in <module>
    class Monitor(Struct):
E   RuntimeError: __class__ not set defining 'Monitor' as <class 'pystachio.typing.Monitor'>. Was __classcell__ propagated to type.__new__?
```