### PR TITLE
Fixup invalid escapes

### DIFF
--- a/pystachio/naming.py
+++ b/pystachio/naming.py
@@ -87,13 +87,13 @@ class Ref(object):
       return self.value > other.value
 
   class Index(Component):
-    RE = re.compile('^[\w\-\./]+$')
+    RE = re.compile(r'^[\w\-\./]+$')
 
     def __repr__(self):
       return '[%s]' % self._value
 
   class Dereference(Component):
-    RE = re.compile('^[^\d\W]\w*$')
+    RE = re.compile(r'^[^\d\W]\w*$')
 
     def __repr__(self):
       return '.%s' % self._value

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from setuptools import Command, find_packages, setup
 
-version = '0.8.9+fcc72a3'
+version = '0.8.9'
 
 
 class PyTest(Command):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from setuptools import Command, find_packages, setup
 
-version = '0.8.9'
+version = '0.8.9+fcc72a3'
 
 
 class PyTest(Command):


### PR DESCRIPTION
Regular expressions use the backslash character ('\') to indicate special forms or to allow special characters to be used without invoking their special meaning. This collides with Python’s usage of the same character for the same purpose in string literals; for example, to match a literal backslash, one might have to write '\\\\' as the pattern string, because the regular expression must be \\, and each backslash must be expressed as \\ inside a regular Python string literal. Also, please note that any invalid escape sequences in Python’s usage of the backslash in string literals now generate a DeprecationWarning and in the future this will become a SyntaxError. This behaviour will happen even if it is a valid escape sequence for a regular expression.

The solution is to use Python’s raw string notation for regular expression patterns; backslashes are not handled in any special way in a string literal prefixed with 'r'. So r"\n" is a two-character string containing '\' and 'n', while "\n" is a one-character string containing a newline. Usually patterns will be expressed in Python code using this raw string notation.